### PR TITLE
Small typo fixes for anyOf case

### DIFF
--- a/prolog/openapi.pl
+++ b/prolog/openapi.pl
@@ -1355,7 +1355,7 @@ json_check(allOf(Types), In, Out) :-
     ;   maplist(json_check_out_in_type(Out), Ins, Types),
         join_dicts(Ins, In)
     ).
-json_check(anyof(Types), In, Out) :-
+json_check(anyOf(Types), In, Out) :-
     !,
     (   member(Type, Types),
         catch(json_check(Type, In, Out), _, fail)
@@ -1590,8 +1590,8 @@ json_type(Spec, allOf(Types), Options) :-
     _{allOf:List} :< Spec,
     !,
     maplist(opts_json_type(Options), List, Types).
-json_type(Spec, oneOf(Types), Options) :-
-    _{oneOf:List} :< Spec,
+json_type(Spec, anyOf(Types), Options) :-
+    _{anyOf:List} :< Spec,
     !,
     maplist(opts_json_type(Options), List, Types).
 json_type(Spec, not(Type), Options) :-
@@ -1614,7 +1614,7 @@ json_type(Spec, Type, Options) :-
     option(base_uri(Base), Options),
     uri_normalized(URLS, Base, URL),
     (   url_type(URL, Spec2)
-    ->  atom_string(NewBase, URLS),
+    ->  atom_string(NewBase, URL),
         json_type(Spec2, Type, [base_uri(NewBase)|Options])
     ;   Type = url(URL)
     ).
@@ -1655,8 +1655,9 @@ numeric_type(number).
 url_type(URL, Type) :-
     uri_components(URL, Components),
     uri_data(scheme, Components, file),
-    uri_data(path, Components, File),
+    uri_data(path, Components, FileEnc),
     uri_data(fragment, Components, Fragment),
+    uri_encoded(path, File, FileEnc),
     openapi_read(File, Spec),
     atomic_list_concat(Segments, /, Fragment),
     yaml_subdoc(Segments, Spec, Type).


### PR DESCRIPTION
My openapi yaml has anyOf and nested type references that seems to be not handled correctly due to the typos. I also added uri decoding in url_type opening file, which is solve issue with windows  paths (e.g "c:/some_path") 

Below  is the sample openapi snippet causing the issues: 

```yaml
components:
  schemas:
    HAL:
      type: object
      properties:
        _links: 
          type: object
          additionalProperties:
            $ref: '#/components/schemas/Links'
        _embeded:
          type: object
          additionalProperties:
            $ref: '#/components/schemas/Links'
    Links: 
      anyOf:
      - $ref: '#/components/schemas/Link'
      - type: array
        items: 
          $ref: '#/components/schemas/Link'
    Link:
      type: object
      description: |
        A Link Object represents a hyperlink from the containing resource to
        a URI. (https://tools.ietf.org/html/draft-kelly-json-hal-08#section-5)
      required:
      - href
      properties: 
        href: 
          type: string
          description: |
            Its value is either a URI [RFC3986] or a URI Template [RFC6570].
            
            If the value is a URI Template then the Link Object SHOULD have a
            "templated" attribute whose value is true.
        templated: 
          type: boolean
          description: |
            Its value is boolean and SHOULD be true when the Link Object's "href"
            property is a URI Template.
          
            Its value SHOULD be considered false if it is undefined or any other
            value than true.
        type: 
          type: string
          description: |
            Its value is a string used as a hint to indicate the media type
            expected when dereferencing the target resource.
        deprecation:
          type: string 
          description: |
           Its presence indicates that the link is to be deprecated (i.e.
           removed) at a future date.  Its value is a URL that SHOULD provide
           further information about the deprecation.
        
           A client SHOULD provide some notification (for example, by logging a
           warning message) whenever it traverses over a link that has this
           property.  The notification SHOULD include the deprecation property's
           value so that a client manitainer can easily find information about
           the deprecation.
        name: 
          type: string
          description: |
            Its value MAY be used as a secondary key for selecting Link Objects
            which share the same relation type.
        profile: 
          type: string
          description: | 
            Its value is a string which is a URI that hints about the profile
            of the target resource.
        title:
          type: string
          description: |
            Its value is a string and is intended for labelling the link with a
            human-readable identifier (as defined by [RFC5988]).
        hreflang: 
          type: string
          description: | 
            Its value is a string and is intended for indicating the language of
            the target resource (as defined by [RFC5988]).
        
    Report:
      allOf: 
      - $ref: '#/components/schemas/HAL'
      - type: object
        properties:
          id:
            type: string
          label:
            type: string
          location:
            type: string
```