### PR TITLE
openapi_handler do not matches path with parameter

### DIFF
--- a/pack.pl
+++ b/pack.pl
@@ -1,5 +1,5 @@
 name(openapi).
-version('0.2').
+version('0.2.1').
 title('OpenAPI (Swagger) interface').
 keywords(['OpenAPI', 'Swagger', 'REST', 'HTTP', service]).
 author( 'Jan Wielemaker', 'J.Wielemaker@vu.nl' ).

--- a/prolog/openapi.pl
+++ b/prolog/openapi.pl
@@ -1227,6 +1227,9 @@ api_type(date,     string,     date,        date).
 api_type(dateTime, string,     'date-time', date_time).
 api_type(password, string,     password,    password).
 api_type(uri,      string,     uri,         uri). % Not in OAS
+api_type(_,        Type,       Format,     _) :- % Print error hint for the unknown type
+    print_message(error, format('Unrecognized type `~w` with format `~w` ', [Type, Format])),
+    fail. 
 
 %!  oas_type(+Type, ?In, ?Out) is det.
 


### PR DESCRIPTION
API paths with parameters (e.g. /report/{id]) are generated in the server clauses M:openapi_handler with the segmented path, while openapi:openapi_dispatch is looking for the predicate with the non-segmented request`s path. I added openapi_handler_match predicate, which compares the request path with the clauses of M:openapi_handler predicate, while taking parameter segmentation into the account. 